### PR TITLE
[Issue Labeler] Do not propagate errors for non-parameter scenarios

### DIFF
--- a/src/Hubbup.MikLabelModel/LabelerLite.cs
+++ b/src/Hubbup.MikLabelModel/LabelerLite.cs
@@ -115,11 +115,11 @@ namespace Hubbup.MikLabelModel
             AssertNotNullOrEmpty(issueUserLogin, nameof(issueUserLogin));
             AssertNotNullOrEmpty(repositoryName, nameof(repositoryName));
             AssertNotNullOrEmpty(repositoryOwnerName, nameof(repositoryOwnerName));
-                        
+
             _logger.LogInformation($"Predict Labels started query for {repositoryOwnerName}/{repositoryName}#{issueNumber}");
-            
-            // Query raw predictions            
-            var issueModel = CreateIssue(issueNumber, title, body, issueUserLogin);        
+
+            // Query raw predictions
+            var issueModel = CreateIssue(issueNumber, title, body, issueUserLogin);
             var predictions = await GetPredictions(repositoryOwnerName, repositoryName, issueNumber, issueModel);
 
             // Determine the confidence threshold to use for filtering predictions
@@ -141,14 +141,14 @@ namespace Hubbup.MikLabelModel
             foreach (var labelSuggestion in predictions)
             {
                 var topChoice = labelSuggestion.LabelScores.OrderByDescending(x => x.Score).First();
-                                
+
                 if (topChoice.Score >= confidenceThreshold)
                 {
                     predictedLabels.Add(topChoice.LabelName);
                 }
                 else
                 {
-                    _logger.LogWarning($"Label prediction was below confidence level `{confidenceThreshold}` for Model:`{labelSuggestion.ModelConfigName ?? defaultModel}`: '{string.Join(", ", labelSuggestion.LabelScores.Select(x => $"{x.LabelName}:[{x.Score}]"))}'");                    
+                    _logger.LogWarning($"Label prediction was below confidence level `{confidenceThreshold}` for Model:`{labelSuggestion.ModelConfigName ?? defaultModel}`: '{string.Join(", ", labelSuggestion.LabelScores.Select(x => $"{x.LabelName}:[{x.Score}]"))}'");
                 }
             }
 

--- a/src/IssueLabeler/AzureSdkIssueLabelerService.cs
+++ b/src/IssueLabeler/AzureSdkIssueLabelerService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Hubbup.MikLabelModel;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.Configuration;
@@ -14,40 +15,60 @@ namespace IssueLabeler
 {
     public class AzureSdkIssueLabelerService : IssueLabelerFunctionBase
     {
+        private static readonly ActionResult EmptyResult = new JsonResult(new PredictionResponse(Array.Empty<string>()));
+
         public AzureSdkIssueLabelerService(ILabelerLite labeler, IModelHolderFactoryLite modelHolderFactory, IConfiguration config)
             : base(labeler, modelHolderFactory, config)
         {
         }
 
         [FunctionName("AzureSdkIssueLabelerService")]
-        public async Task<PredictionResponse> Run([HttpTrigger(AuthorizationLevel.Function, "POST", Route = null)] HttpRequest request, ILogger log)
+        public async Task<ActionResult> Run([HttpTrigger(AuthorizationLevel.Function, "POST", Route = null)] HttpRequest request, ILogger log)
         {
-            using var bodyReader = new StreamReader(request.Body);
+            IssuePayload issue;
 
-            var requestBody = await bodyReader.ReadToEndAsync();
-            var issue = JsonConvert.DeserializeObject<IssuePayload>(requestBody);
-
-            // In order for labels to be valid for Azure SDK use, there must
-            // be at least two of them, which corresponds to a Service (pink)
-            // and Category (yellow).  If that is not met, then no predictions
-            // should be returned.
-            var predictions = await Labeler.QueryLabelPrediction(
-                issue.IssueNumber,
-                issue.Title,
-                issue.Body,
-                issue.IssueUserLogin,
-                issue.RepositoryName,
-                issue.RepositoryOwnerName);
-
-            if (predictions.Count < 2)
+            try
             {
-                return new PredictionResponse(Array.Empty<string>());
+                using var bodyReader = new StreamReader(request.Body);
+
+                var requestBody = await bodyReader.ReadToEndAsync();
+                issue = JsonConvert.DeserializeObject<IssuePayload>(requestBody);
+            }
+            catch (Exception ex)
+            {
+                log.LogError($"Unable to deserialize payload:{ex.Message}{Environment.NewLine}\t{ex}{Environment.NewLine}");
+                return new BadRequestResult();
             }
 
-            return new PredictionResponse(predictions);
+            try
+            {
+                // In order for labels to be valid for Azure SDK use, there must
+                // be at least two of them, which corresponds to a Service (pink)
+                // and Category (yellow).  If that is not met, then no predictions
+                // should be returned.
+                var predictions = await Labeler.QueryLabelPrediction(
+                    issue.IssueNumber,
+                    issue.Title,
+                    issue.Body,
+                    issue.IssueUserLogin,
+                    issue.RepositoryName,
+                    issue.RepositoryOwnerName);
+
+                if (predictions.Count < 2)
+                {
+                    return EmptyResult;
+                }
+
+                return new JsonResult(new PredictionResponse(predictions));
+            }
+            catch (Exception ex)
+            {
+                log.LogError($"Error querying predictions: {ex.Message}{Environment.NewLine}\t{ex}{Environment.NewLine}");
+                return EmptyResult;
+            }
         }
 
-        // Private type used for deserializing the request paylod of issue data.
+        // Private type used for deserializing the request payload of issue data.
         private class IssuePayload
         {
             public int IssueNumber;

--- a/src/IssueLabeler/IssueLabeler.cs
+++ b/src/IssueLabeler/IssueLabeler.cs
@@ -1,19 +1,13 @@
-using Hubbup.MikLabelModel;
-using Microsoft.Azure.WebJobs;
-using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System;
-using System.Linq;
 using Azure.Messaging.EventHubs;
-using System.Diagnostics;
-using IssueLabeler.Shared.Models;
+using Hubbup.MikLabelModel;
+using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Configuration;
-using System.Diagnostics.Contracts;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Logging;
 
 namespace IssueLabeler
 {

--- a/src/IssueLabeler/IssueLabeler.csproj
+++ b/src/IssueLabeler/IssueLabeler.csproj
@@ -21,7 +21,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="local.settings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
   </ItemGroup>

--- a/src/IssueLabeler/IssueLabeler.csproj
+++ b/src/IssueLabeler/IssueLabeler.csproj
@@ -21,7 +21,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="local.settings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
   </ItemGroup>

--- a/src/IssueLabeler/IssueLabelerFunctionBase.cs
+++ b/src/IssueLabeler/IssueLabelerFunctionBase.cs
@@ -4,8 +4,8 @@ using Microsoft.Extensions.Configuration;
 
 namespace IssueLabeler
 {
-	public abstract class IssueLabelerFunctionBase
-	{
+    public abstract class IssueLabelerFunctionBase
+    {
         protected ILabelerLite Labeler { get; }
         protected IConfiguration Config { get; }
 


### PR DESCRIPTION
# Summary

The focus of these changes is to add validation to the label endpoint to log error details and return an empty set of predictions for non-parameter errors.  For a malformed parameter, an HTTP 400 (Bad Request) will be returned.